### PR TITLE
Feature/gen did with version

### DIFF
--- a/indy-utils/Cargo.toml
+++ b/indy-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indy-utils"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Hyperledger Indy Contributors <indy@lists.hyperledger.org>"]
 description = "Utilities for Hyperledger Indy (https://www.hyperledger.org/projects), which provides a distributed-ledger-based foundation for self-sovereign identity (https://sovrin.org)."
 edition = "2018"
@@ -24,8 +24,8 @@ txn_signature = ["hex", "sha2", "serde", "serde_json"]
 wql = ["indy-wql", "serde", "serde_json"]
 
 [dependencies]
-base64_rs = { package = "base64", version = "0.12", optional = true }
-bs58 = "0.3"
+base64_rs = { package = "base64", version = "0.13", optional = true }
+bs58 = "0.4"
 curve25519-dalek = { version = "3.1", default-features = false, features = ["u64_backend"], optional = true }
 ed25519-dalek = { version = "1.0", default-features = false, features = ["u64_backend"], optional = true }
 hex = { version = "0.4", optional = true }
@@ -35,9 +35,9 @@ rand = { version = "0.8", optional = true }
 regex = "1.3"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-sha2 = { version = "0.9", optional = true }
+sha2 = { version = "0.10", optional = true }
 thiserror = "1.0"
-x25519-dalek = { version = "=1.1", default-features = false, features = ["u64_backend"], optional = true }
+x25519-dalek = { version = "=1.2", default-features = false, features = ["u64_backend"], optional = true }
 zeroize = { version = "1.3" }
 
 [dev-dependencies]


### PR DESCRIPTION
Adds optional parameter `version` to `generate_did` method. 

if `version == None | 1` : DID will be self-certified according to did:sov convention
if `version == 2`: DID will be self-certified according to did:indy specification